### PR TITLE
Fix satoshi conversions.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["mix.exs", "{config,apps}/**/*.{ex,exs}"],
+  line_length: 100
+]

--- a/lib/money.ex
+++ b/lib/money.ex
@@ -214,7 +214,7 @@ defmodule Money do
       amount
       |> abs()
       |> Integer.to_string
-      |> String.split_at(-unit_precision)
+      |> split_at(-unit_precision)
 
     minus_sign
     <>
@@ -240,6 +240,10 @@ defmodule Money do
         |> String.pad_leading(1, "0"))
     end
   end
+
+  defp split_at(string, 0), do: {string, ""}
+
+  defp split_at(string, precision), do: String.split_at(string, precision)
 
   @doc """
   Converts from Money to floats.

--- a/mix.exs
+++ b/mix.exs
@@ -11,25 +11,27 @@ defmodule Money.Mixfile do
       source_url: "https://github.com/heathmont/money-elixir",
       version: @vsn,
       elixir: "~> 1.4",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
-      elixirc_paths: elixirc_paths(Mix.env),
-      deps: deps(),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      deps: deps()
     ]
   end
 
   def application do
-    [extra_applications: [
-      :logger,
-    ]]
+    [
+      extra_applications: [
+        :logger
+      ]
+    ]
   end
 
   defp deps do
     [
-      {:poison, "~> 3.0"},
+      {:poison, "~> 3.0"}
     ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 end


### PR DESCRIPTION
wrap around String.split_at in case of 0. Solves corner case for satoshies
**Before:**
```
iex(1)> [1,10,100,1000] |> Enum.each(fn x -> Money.to_money(x, "BTC", "sat") |> Money.to_string() |> IO.puts()end)
0.1
0.1
0.1
0.1
:ok
iex(2)> [1,10,100,1000] |> Enum.each(fn x -> Money.to_money(x, "BTC", "uBTC") |> Money.to_string() |> IO.puts()end)
1.0
10.0
100.0
1000.0
:ok
iex(3)> [1,10,100,1000] |> Enum.each(fn x -> Money.to_money(x, "BTC", "mBTC") |> Money.to_string() |> IO.puts()end)
1.0
10.0
100.0
1000.0
:ok
```
**After:**
```
iex(12)> [1,10,100,1000] |> Enum.each(fn x -> Money.to_money(x, "BTC", "sat") |> Money.to_string() |> IO.puts()end)
1.0
10.0
100.0
1000.0
:ok
iex(13)> [1,10,100,1000] |> Enum.each(fn x -> Money.to_money(x, "BTC", "uBTC") |> Money.to_string() |> IO.puts()end)
1.0
10.0
100.0
1000.0
:ok
iex(14)> [1,10,100,1000] |> Enum.each(fn x -> Money.to_money(x, "BTC", "mBTC") |> Money.to_string() |> IO.puts()end)
1.0
10.0
100.0
1000.0
:ok
```